### PR TITLE
allow 0 values for nf fields when building full nutrients; do not all…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,9 +102,9 @@ function convertV1ItemToTrackFood(v1Item, defaultObj) {
  */
 function buildFullNutrientsArray(data) {
   return _.reduce(nutrientsMap, function(accum, nutrDetails, v1AttrName) {
-    if (data[v1AttrName]) {
+    if (data[v1AttrName] || data[v1AttrName] === 0) {
       let value   = parseFloat(data[v1AttrName]);
-      if (!isNaN(value)) {
+      if (!isNaN(value) && !(value < 0)) {
         let attr_id = nutrDetails.attr_id;
         //ensure that daily value measures are calculated into the appropriate units.
         if (dailyValueTransforms[attr_id]) {


### PR DESCRIPTION
…ow negative values

@Yurko-Fedoriv Can you please merge and publish new version in npm? Issue arrises when sending the value 0 as an nf attribute to the build full nutrients array. We also do not want to allow negative values to be passed in. Thanks!